### PR TITLE
Update GitHub Actions to latest major versions

### DIFF
--- a/.cursor/rules/security-audit.mdc
+++ b/.cursor/rules/security-audit.mdc
@@ -233,7 +233,7 @@ jobs:
   security-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run Security Audit
         run: |

--- a/.github/workflows/sdk_node.yml
+++ b/.github/workflows/sdk_node.yml
@@ -14,9 +14,9 @@ jobs:
       run:
         working-directory: js-sdk
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'
@@ -32,9 +32,9 @@ jobs:
       run:
         working-directory: js-sdk
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: '16.x'
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Bump actions/checkout from v3 to v4 and actions/setup-node from v3 to v4 in workflow and security audit configuration files to use the latest features and security updates.