### PR TITLE
Add re-export modules and fix import path

### DIFF
--- a/erh/analysis/statistics.py
+++ b/erh/analysis/statistics.py
@@ -1,0 +1,20 @@
+"""
+Re-export statistics from shared core for erh.analysis.
+
+Allows 'from erh.analysis.statistics import compare_judges' etc.
+Implementation lives in erh_core.analysis.statistics.
+"""
+
+from erh_core.analysis.statistics import (
+    fit_error_growth,
+    compare_judges,
+    detect_structural_bias,
+    generate_report,
+)
+
+__all__ = [
+    "fit_error_growth",
+    "compare_judges",
+    "detect_structural_bias",
+    "generate_report",
+]

--- a/erh_core/analysis/edge_cases.py
+++ b/erh_core/analysis/edge_cases.py
@@ -7,7 +7,7 @@ logical completeness and consistency.
 
 import numpy as np
 from typing import List, Dict, Optional
-from .action_space import Action
+from erh_core.core.action_space import Action
 try:
     from erh_core.core.ethical_primes import compute_Pi_and_error, analyze_error_growth
     from erh_core.core.judgement_system import BaseJudge

--- a/simulation/analysis/statistics.py
+++ b/simulation/analysis/statistics.py
@@ -1,0 +1,20 @@
+"""
+Re-export statistics from shared core for simulation.analysis.
+
+Allows 'from simulation.analysis.statistics import compare_judges' etc.
+to work; implementation lives in erh_core.analysis.statistics.
+"""
+
+from erh_core.analysis.statistics import (
+    fit_error_growth,
+    compare_judges,
+    detect_structural_bias,
+    generate_report,
+)
+
+__all__ = [
+    "fit_error_growth",
+    "compare_judges",
+    "detect_structural_bias",
+    "generate_report",
+]


### PR DESCRIPTION
Add re-export modules erh/analysis/statistics.py and simulation/analysis/statistics.py to expose functions from erh_core.analysis.statistics (fit_error_growth, compare_judges, detect_structural_bias, generate_report) so callers can import them via the package namespaces. Also update erh_core/analysis/edge_cases.py to use an absolute import (erh_core.core.action_space.Action) instead of a relative import to avoid import resolution issues.